### PR TITLE
fix: allow flexible dev server port and update tauri config

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
 	// tauri expects a fixed port, fail if that port is not available
 	server: {
 		port: 1420,
-		strictPort: true,
+		strictPort: false,
 		fs: {
 			strict: false
 		}

--- a/crates/gitbutler-tauri/tauri.conf.json
+++ b/crates/gitbutler-tauri/tauri.conf.json
@@ -4,8 +4,7 @@
 	"build": {
 		"beforeDevCommand": "pnpm dev:internal-tauri",
 		"beforeBuildCommand": "[ \"$CI\" = \"true\" ] || pnpm build:desktop -- --mode development",
-		"frontendDist": "../../apps/desktop/build",
-		"devUrl": "http://localhost:1420"
+		"frontendDist": "../../apps/desktop/build"
 	},
 	"bundle": {
 		"active": false,


### PR DESCRIPTION
Set strictPort to false in vite.config.ts to avoid failing when port
1420 is unavailable, improving development flexibility. Remove devUrl
from tauri.conf.json to align with updated build process and avoid
conflicts during development.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The dev server now allows any available port if 1420 is taken, making local development easier. Removed the devUrl setting from the Tauri config to match the new build process and prevent conflicts.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development server configuration to allow automatic port selection if the default port is unavailable.
  - Removed an unused property from the build configuration to streamline setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->