### PR TITLE
feat(windows-title-bar): add editor badge to title bar

### DIFF
--- a/apps/desktop/src/components/WindowsTitleBar.svelte
+++ b/apps/desktop/src/components/WindowsTitleBar.svelte
@@ -197,6 +197,14 @@
 	const showTitleBar = $derived(platformName === 'windows');
 </script>
 
+{#snippet editorBadgeSnippet()}
+	{#if $userSettings.defaultCodeEditor?.displayName}
+		<Badge style="neutral" size="icon">
+			{$userSettings.defaultCodeEditor.displayName}
+		</Badge>
+	{/if}
+{/snippet}
+
 {#if showTitleBar}
 	<div class="title-bar" data-tauri-drag-region>
 		<!-- App Icon and Info Section -->
@@ -325,6 +333,7 @@
 									openExternalUrl(path);
 								}
 							}}
+							control={editorBadgeSnippet}
 						/>
 					</ContextMenuSection>
 					<ContextMenuSection>


### PR DESCRIPTION
Display the default code editor's name as a badge in the Windows title
bar when set in user settings. This improves visibility of the selected
editor and enhances user context. Integrate the badge snippet into the
context menu control for consistent UI behavior.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Shows the selected code editor as a badge in the Windows title bar when set in user settings. This makes it easier for users to see which editor is active.

- **UI Improvements**
  - Displays the editor badge in the title bar and context menu for a consistent look.

<!-- End of auto-generated description by cubic. -->

