### PR TITLE
fix(desktop): apply padding only with custom title bar on Windows

### DIFF
--- a/apps/desktop/src/components/WindowsTitleBar.svelte
+++ b/apps/desktop/src/components/WindowsTitleBar.svelte
@@ -622,8 +622,8 @@
 		flex-shrink: 0;
 	}
 
-	/* Ensure content doesn't overlap with title bar */
-	:global(.app-root) {
+	/* Ensure content doesn't overlap with title bar - only when custom title bar is shown */
+	:global(.app-root.has-custom-titlebar) {
 		padding-top: 40px; /* Matches the increased title bar height */
 	}
 

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -308,7 +308,12 @@
 	onkeydown={handleKeyDown}
 />
 
-<div class="app-root" role="application" oncontextmenu={(e) => !dev && e.preventDefault()}>
+<div
+	class="app-root"
+	class:has-custom-titlebar={platformName === 'windows' && $userSettings.useCustomTitleBar}
+	role="application"
+	oncontextmenu={(e) => !dev && e.preventDefault()}
+>
 	{#if platformName === 'macos' && !$settingsStore?.featureFlags.v3}
 		<div class="drag-region" data-tauri-drag-region></div>
 	{/if}


### PR DESCRIPTION
Update app-root padding to apply only when the custom title bar is shown,
preventing unnecessary top padding on other platforms or default title bars.
Add conditional has-custom-titlebar class based on platform and user settings
to control this styling dynamically. This ensures content does not overlap
the title bar only when needed, improving layout consistency.