### PR TITLE
windows-custom-titlebar-ui-refactor

### DIFF
--- a/apps/desktop/src/components/WindowsTitleBar.svelte
+++ b/apps/desktop/src/components/WindowsTitleBar.svelte
@@ -567,6 +567,7 @@
 
 	.title-bar__menu :global(.dropdown-wrapper) {
 		display: flex;
+		margin: 0;
 	}
 
 	/* Hide dropdown icons, separators, and vertical lines */
@@ -582,7 +583,7 @@
 	/* Style individual menu buttons as plain text */
 	.title-bar__menu :global(.dropdown-wrapper .btn) {
 		height: 24px;
-		padding: 4px 1px;
+		padding: 4px 2px;
 		gap: 0 !important;
 		border: none !important;
 		border-radius: 0 !important;
@@ -593,6 +594,8 @@
 		opacity: 0.5;
 		pointer-events: all !important;
 		transition: opacity var(--transition-fast);
+		width: fit-content;
+		min-width: auto;
 	}
 
 	.title-bar__menu :global(.dropdown-wrapper .btn:hover) {

--- a/apps/desktop/src/components/WindowsTitleBar.svelte
+++ b/apps/desktop/src/components/WindowsTitleBar.svelte
@@ -215,8 +215,8 @@
 	// Note: Project-specific shortcuts ('history', 'project-settings', 'open-in-vscode')
 	// are handled by ProjectSettingsMenuAction.svelte to avoid conflicts
 
-	// Only show on Windows and when custom title bar is enabled
-	const showTitleBar = $derived(platformName === 'windows' && $userSettings.useCustomTitleBar);
+	// Always show custom title bar on Windows
+	const showTitleBar = $derived(platformName === 'windows');
 </script>
 
 {#snippet editorBadgeSnippet()}

--- a/apps/desktop/src/components/v3/projectSettings/AppearanceSettings.svelte
+++ b/apps/desktop/src/components/v3/projectSettings/AppearanceSettings.svelte
@@ -292,31 +292,3 @@
 		/>
 	{/snippet}
 </SectionCard>
-
-{#if platformName === 'windows'}
-	<SectionCard labelFor="useCustomTitleBar" orientation="row">
-		{#snippet title()}
-			Use custom title bar
-		{/snippet}
-		{#snippet caption()}
-			Use GitButler's custom title bar with menu items. When disabled, the default Windows title bar
-			will be used.
-		{/snippet}
-		{#snippet actions()}
-			<Toggle
-				id="useCustomTitleBar"
-				checked={$userSettings.useCustomTitleBar}
-				onclick={async () => {
-					const newValue = !$userSettings.useCustomTitleBar;
-					userSettings.update((s) => ({
-						...s,
-						useCustomTitleBar: newValue
-					}));
-					// Update window decorations immediately
-					// Decorations are inverted: true = show default title bar, false = hide default title bar
-					await tauri.setDecorations(!newValue);
-				}}
-			/>
-		{/snippet}
-	</SectionCard>
-{/if}

--- a/apps/desktop/src/lib/settings/userSettings.ts
+++ b/apps/desktop/src/lib/settings/userSettings.ts
@@ -29,7 +29,6 @@ export interface Settings {
 	inlineUnifiedDiffs: boolean;
 	diffContrast: 'light' | 'medium' | 'strong';
 	defaultCodeEditor: CodeEditorSettings;
-	useCustomTitleBar: boolean;
 }
 
 const defaults: Settings = {
@@ -50,8 +49,7 @@ const defaults: Settings = {
 	diffLigatures: false,
 	inlineUnifiedDiffs: false,
 	diffContrast: 'light',
-	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' },
-	useCustomTitleBar: true
+	defaultCodeEditor: { schemeIdentifer: 'vscode', displayName: 'VSCode' }
 };
 
 export function loadUserSettings(): Writable<Settings> {

--- a/apps/desktop/src/routes/+layout.svelte
+++ b/apps/desktop/src/routes/+layout.svelte
@@ -262,12 +262,11 @@
 	let shareIssueModal: ShareIssueModal;
 
 	onMount(() => {
-		// Initialize window decorations based on user settings
-		// Only on Windows platform
+		// Initialize window decorations for Windows
+		// Always use custom title bar on Windows, so hide default decorations
 		if (platformName === 'windows') {
-			const currentSettings = $userSettings;
 			// Decorations are inverted: true = show default title bar, false = hide default title bar
-			data.tauri.setDecorations(!currentSettings.useCustomTitleBar);
+			data.tauri.setDecorations(false);
 		}
 
 		return unsubscribe(
@@ -310,7 +309,7 @@
 
 <div
 	class="app-root"
-	class:has-custom-titlebar={platformName === 'windows' && $userSettings.useCustomTitleBar}
+	class:has-custom-titlebar={platformName === 'windows'}
 	role="application"
 	oncontextmenu={(e) => !dev && e.preventDefault()}
 >


### PR DESCRIPTION
### Description

- Always use the custom title bar on Windows by default; removed the toggle and user setting for this feature.
- Updated window decorations initialization to consistently hide the default Windows title bar.
- Adjusted WindowsTitleBar menu button spacing and styles for better alignment, sizing, and visual consistency.
- Reorganized imports and streamlined project state logic in WindowsTitleBar.svelte for improved readability and maintainability.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The custom title bar is now always used on Windows, and the user setting to toggle it has been removed for a simpler, more consistent UI.

- **Refactors**
  - Cleaned up WindowsTitleBar code and imports.
  - Improved menu button spacing and styles for better alignment.

<!-- End of auto-generated description by cubic. -->

